### PR TITLE
Removed alias_method_chain in favor of replacement prepend method

### DIFF
--- a/lib/soft_delete.rb
+++ b/lib/soft_delete.rb
@@ -116,7 +116,7 @@ end
 
 module ActiveRecord
   module Validations
-    class UniquenessValidator < ActiveModel::EachValidator
+    module UniquenessSoftDeleteValidator
       protected
       def build_relation_with_soft_delete(klass, table, attribute, value)
         relation = build_relation_without_soft_delete(klass, table, attribute, value)
@@ -126,7 +126,10 @@ module ActiveRecord
           relation
         end
       end
-      alias_method_chain :build_relation, :soft_delete
+    end
+
+    class UniquenessValidator < ActiveModel::EachValidator
+      prepend UniquenessSoftDeleteValidator
     end
   end
 end

--- a/lib/soft_delete.rb
+++ b/lib/soft_delete.rb
@@ -118,8 +118,9 @@ module ActiveRecord
   module Validations
     module UniquenessSoftDeleteValidator
       protected
-      def build_relation_with_soft_delete(klass, table, attribute, value)
-        relation = build_relation_without_soft_delete(klass, table, attribute, value)
+      def build_relation(klass, table, attribute, value)
+        relation = super(klass, table, attribute, value)
+
         if klass.soft_deletable?
           relation.where(klass.arel_table[:deleted_at].eq(nil))
         else


### PR DESCRIPTION
`Deprecated alias_method_chain in favour of Module#prepend introduced in Ruby 2.0. ` [See here for details](http://edgeguides.rubyonrails.org/5_0_release_notes.html)

This solution is copied from paranoia's fix to use `Module#prepend` in place of `alias_method_chain` [See paranoia.rb](https://github.com/rubysherpas/paranoia/blob/rails5/lib/paranoia.rb#L265) for their implementation. 