### PR TITLE
Adapt soft_delete gem to paranoia 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'sqlite3', :platforms => [:ruby]
+gem 'sqlite3', platforms: [:ruby]
+
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+end
 
 platforms :rbx do
   gem 'rubysl', '~> 2.0'

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ class Client < ActiveRecord::Base
 end
 ```
 
-
 If you want to access soft-deleted associations, override the getter method:
 
 ``` ruby
@@ -106,8 +105,6 @@ def product
   Product.unscoped { super }
 end
 ```
-
-
 
 If you want to include associated soft-deleted objects in Rails 4+, you can (un)scope the association:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gem "soft_delete", :github => "optimalworkshop/soft_delete", :branch => "rails4"
 For Rails 4.2 and 5, please use version 4 of Soft Delete:
 
 ``` ruby
-gem "soft_delete", "~> 4.0"  :github => "optimalworkshop/soft_delete"
+gem "soft_delete", :github => "optimalworkshop/soft_delete", :tag => "v4.0.0"
 ```
 
 

--- a/lib/soft_delete.rb
+++ b/lib/soft_delete.rb
@@ -1,21 +1,41 @@
 require 'active_record' unless defined? ActiveRecord
 
 module SoftDelete
+  @@default_sentinel_value = nil
+
+  # Change default_sentinel_value in a rails initializer
+  def self.default_sentinel_value=(val)
+    @@default_sentinel_value = val
+  end
+
+  def self.default_sentinel_value
+    @@default_sentinel_value
+  end
 
   def self.included(klazz)
     klazz.extend Query
-    klazz.extend Callbacks
   end
 
   module Query
     def soft_deletable? ; true ; end
 
     def with_deleted
-      unscope where: :deleted_at
+      unscope(where: soft_delete_column)
     end
 
     def only_deleted
       with_deleted.where.not(deleted_at: nil)
+
+      if soft_delete_sentinel_value.nil?
+        return with_deleted.where.not(soft_delete_column => soft_delete_sentinel_value)
+      end
+      # if soft_delete_sentinel_value is not null, then it is possible that
+      # some deleted rows will hold a null value in the soft_delete column
+      # these will not match != sentinel value because "NULL != value" is
+      # NULL under the sql standard
+      # Scoping with the table_name is mandatory to avoid ambiguous errors when joining tables.
+      scoped_quoted_soft_delete_column = "#{self.table_name}.#{connection.quote_column_name(soft_delete_column)}"
+      with_deleted.where("#{scoped_quoted_soft_delete_column} IS NULL OR #{scoped_quoted_soft_delete_column} != ?", soft_delete_sentinel_value)
     end
     alias :deleted :only_deleted
 
@@ -31,34 +51,39 @@ module SoftDelete
     end
   end
 
-  module Callbacks
-    def self.extended(klazz)
-      [:restore, :soft_delete].each do |callback_name|
-        klazz.define_model_callbacks :"#{callback_name}"
+  def soft_delete
+    transaction do
+      run_callbacks(:soft_delete) do
+        @_disable_counter_cache = deleted?
+        result = soft_delete_touch
+        next result unless result
+        each_counter_cached_associations do |association|
+          next unless send(association.reflection.name)
+          association.decrement_counters
+        end
+        @_disable_counter_cache = false
+        result
       end
     end
   end
 
   def soft_delete!
-    transaction do
-      run_callbacks(:soft_delete) do
-        result = touch_deleted_at
-        each_counter_cached_associations do |association|
-          if send(association.reflection.name)
-            association.decrement_counters
-          end
-        end
-        result
-      end
-    end
+    soft_delete ||
+      raise(ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record", self))
   end
-  alias :soft_delete :soft_delete!
 
   def restore!(opts = {})
     self.class.transaction do
       run_callbacks(:restore) do
-        write_attribute :deleted_at, nil
-        update_column :deleted_at, nil
+        @_disable_counter_cache = !soft_deleted?
+        write_attribute soft_delete_column, soft_delete_sentinel_value
+        update_columns(soft_delete_restore_attributes)
+        each_counter_cached_associations do |association|
+          if send(association.reflection.name)
+            association.increment_counters
+          end
+        end
+        @_disable_counter_cache = false
       end
     end
 
@@ -67,70 +92,122 @@ module SoftDelete
   alias :restore :restore!
 
   def soft_deleted?
-    deleted_at?
+    send(soft_delete_column) != soft_delete_sentinel_value
   end
   alias :deleted? :soft_deleted?
 
   private
 
-    def touch_deleted_at
-      raise ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
-      if persisted?
-        touch(:deleted_at)
-      elsif !frozen?
-        write_attribute(:deleted_at, current_time_from_proper_timezone)
-      end
-
-      self
-    end
-
-end
-
-class ActiveRecord::Base
-  def self.acts_as_soft_deletable(options={})
-    include SoftDelete
-
-    def self.soft_delete_scope
-      where(deleted_at: nil)
-    end
-    default_scope { soft_delete_scope }
-
-    before_restore {
-      self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)
-    }
-    after_restore {
-      self.class.notify_observers(:after_restore, self) if self.class.respond_to?(:notify_observers)
-    }
-    before_soft_delete {
-      self.class.notify_observers(:before_soft_delete, self) if self.class.respond_to?(:notify_observers)
-    }
-    after_soft_delete {
-      self.class.notify_observers(:after_soft_delete, self) if self.class.respond_to?(:notify_observers)
-    }
+  def each_counter_cached_associations
+    !(defined?(@_disable_counter_cache) && @_disable_counter_cache) ? super : []
   end
 
-  def self.soft_deletable? ; false ; end
-  def soft_deletable? ; self.class.soft_deletable? ; end
+  def soft_delete_restore_attributes
+    {
+      soft_delete_column => soft_delete_sentinel_value
+    }.merge(timestamp_attributes_with_current_time)
+  end
 
+  def soft_delete_attributes
+    {
+      soft_delete_column => current_time_from_proper_timezone
+    }.merge(timestamp_attributes_with_current_time)
+  end
+
+  def timestamp_attributes_with_current_time
+    timestamp_attributes_for_update_in_model.each_with_object({}) { |attr, hash| hash[attr] = current_time_from_proper_timezone }
+  end
+
+  def soft_delete_touch
+    raise ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
+    if persisted?
+      # if a transaction exists, add the record so that after_commit
+      # callbacks can be run
+      add_to_transaction
+      update_columns(soft_delete_attributes)
+    elsif !frozen?
+      assign_attributes(soft_delete_attributes)
+    end
+
+    self
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  class ActiveRecord::Base
+    def self.acts_as_soft_deletable(options={})
+      define_model_callbacks :restore, :soft_delete
+      include SoftDelete
+      class_attribute :soft_delete_column, :soft_delete_sentinel_value
+
+      self.soft_delete_column = (options[:column] || :deleted_at).to_s
+      self.soft_delete_sentinel_value = options.fetch(:sentinel_value) { SoftDelete.default_sentinel_value }
+
+      def self.soft_delete_scope
+        where(soft_delete_column => soft_delete_sentinel_value)
+      end
+      class << self; alias_method :without_deleted, :soft_delete_scope end
+
+      unless options[:without_default_scope]
+        default_scope { soft_delete_scope }
+      end
+
+      before_restore {
+        self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)
+      }
+      after_restore {
+        self.class.notify_observers(:after_restore, self) if self.class.respond_to?(:notify_observers)
+      }
+      before_soft_delete {
+        self.class.notify_observers(:before_soft_delete, self) if self.class.respond_to?(:notify_observers)
+      }
+      after_soft_delete {
+        self.class.notify_observers(:after_soft_delete, self) if self.class.respond_to?(:notify_observers)
+      }
+    end
+
+    def self.soft_deletable? ; false ; end
+    def soft_deletable? ; self.class.soft_deletable? ; end
+
+    private
+
+    def soft_delete_column
+      self.class.soft_delete_column
+    end
+
+    def soft_delete_sentinel_value
+      self.class.soft_delete_sentinel_value
+    end
+  end
 end
 
 module ActiveRecord
   module Validations
     module UniquenessSoftDeleteValidator
       protected
-      def build_relation(klass, attribute, value)
-        relation = super(klass, attribute, value)
-
-        if klass.soft_deletable?
-          relation.where(klass.arel_table[:deleted_at].eq(nil))
+      def build_relation(klass, *args)
+        relation = super
+        return relation unless klass.respond_to?(:soft_delete_column)
+        arel_soft_delete_scope = klass.arel_table[klass.soft_delete_column].eq(klass.soft_delete_sentinel_value)
+        if ActiveRecord::VERSION::STRING >= "5.0"
+          relation.where(arel_soft_delete_scope)
         else
-          relation
+          relation.and(arel_soft_delete_scope)
         end
       end
     end
 
     class UniquenessValidator < ActiveModel::EachValidator
       prepend UniquenessSoftDeleteValidator
+    end
+
+    class AssociationNotSoftDeletedValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        # if association is soft destroyed, add an error
+        if value.present? && value.soft_deleted?
+          record.errors[attribute] << 'has been soft-deleted'
+        end
+      end
     end
   end
 end

--- a/lib/soft_delete.rb
+++ b/lib/soft_delete.rb
@@ -24,8 +24,6 @@ module SoftDelete
     end
 
     def only_deleted
-      with_deleted.where.not(deleted_at: nil)
-
       if soft_delete_sentinel_value.nil?
         return with_deleted.where.not(soft_delete_column => soft_delete_sentinel_value)
       end
@@ -69,7 +67,7 @@ module SoftDelete
 
   def soft_delete!
     soft_delete ||
-      raise(ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record", self))
+      raise(ActiveRecord::RecordNotDestroyed.new("Failed to soft delete the record", self))
   end
 
   def restore!(opts = {})

--- a/lib/soft_delete/version.rb
+++ b/lib/soft_delete/version.rb
@@ -1,3 +1,3 @@
 module SoftDelete
-  VERSION = "3.0.0"
+  VERSION = "4.0.0"
 end

--- a/soft_delete.gemspec
+++ b/soft_delete.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "activerecord", "~> 5.0"
+  s.add_dependency 'activerecord', '>= 4.2', '< 5.2'
 
   s.add_development_dependency "bundler", ">= 1.15.0"
   s.add_development_dependency "rake"

--- a/test/soft_delete_test.rb
+++ b/test/soft_delete_test.rb
@@ -1,8 +1,12 @@
 require 'active_record'
 require 'minitest/autorun'
+require 'soft_delete'
+
 test_framework = defined?(MiniTest::Test) ? MiniTest::Test : MiniTest::Unit::TestCase
 
-require File.expand_path(File.dirname(__FILE__) + "/../lib/soft_delete")
+if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks=)
+  ActiveRecord::Base.raise_in_transactional_callbacks = true
+end
 
 def connect!
   ActiveRecord::Base.establish_connection :adapter => 'sqlite3', database: ':memory:'
@@ -14,6 +18,14 @@ def setup!
     'parent_model_with_counter_cache_columns' => 'related_models_count INTEGER DEFAULT 0',
     'parent_models' => 'deleted_at DATETIME',
     'soft_deletable_models' => 'parent_model_id INTEGER, deleted_at DATETIME',
+    'soft_deletable_model_with_belongs' => 'parent_model_id INTEGER, deleted_at DATETIME, soft_deletable_model_with_has_one_id INTEGER',
+    'soft_deletable_model_with_build_belongs' => 'parent_model_id INTEGER, deleted_at DATETIME, soft_deletable_model_with_has_one_and_build_id INTEGER, name VARCHAR(32)',
+    'soft_deletable_model_with_anthor_class_name_belongs' => 'parent_model_id INTEGER, deleted_at DATETIME, soft_deletable_model_with_has_one_id INTEGER',
+    'soft_deletable_model_with_foreign_key_belongs' => 'parent_model_id INTEGER, deleted_at DATETIME, has_one_foreign_key_id INTEGER',
+    'soft_deletable_model_with_timestamps' => 'parent_model_id INTEGER, created_at DATETIME, updated_at DATETIME, deleted_at DATETIME',
+    'not_soft_deletable_model_with_belongs' => 'parent_model_id INTEGER, soft_deletable_model_with_has_one_id INTEGER',
+    'not_soft_deletable_model_with_belongs_and_assocation_not_soft_deleted_validator' => 'parent_model_id INTEGER, soft_deletable_model_with_has_one_id INTEGER',
+    'soft_deletable_model_with_has_one_and_builds' => 'parent_model_id INTEGER, color VARCHAR(32), deleted_at DATETIME, has_one_foreign_key_id INTEGER',
     'featureful_models' => 'deleted_at DATETIME, name VARCHAR(32)',
     'plain_models' => 'deleted_at DATETIME',
     'callback_models' => 'deleted_at DATETIME',
@@ -23,7 +35,18 @@ def setup!
     'employers' => 'name VARCHAR(32), deleted_at DATETIME',
     'employees' => 'deleted_at DATETIME',
     'jobs' => 'employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME',
-    'non_soft_deletable_unique_models' => 'name VARCHAR(32), soft_deletable_with_non_soft_deletables_id INTEGER'
+    'custom_column_models' => 'destroyed_at DATETIME',
+    'custom_sentinel_models' => 'deleted_at DATETIME NOT NULL',
+    'non_soft_deletable_models' => 'parent_model_id INTEGER',
+    'polymorphic_models' => 'parent_id INTEGER, parent_type STRING, deleted_at DATETIME',
+    'namespaced_soft_deletable_has_ones' => 'deleted_at DATETIME, soft_deletable_belongs_tos_id INTEGER',
+    'namespaced_soft_deletable_belongs_tos' => 'deleted_at DATETIME, soft_deletable_has_one_id INTEGER',
+    'non_soft_deletable_unique_models' => 'name VARCHAR(32), soft_deletable_with_non_soft_deletables_id INTEGER',
+    'active_column_models' => 'deleted_at DATETIME, active BOOLEAN',
+    'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
+    'soft_deletable_model_with_belongs_to_active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN, active_column_model_with_has_many_relationship_id INTEGER',
+    'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
+    'without_default_scope_models' => 'deleted_at DATETIME'
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
   end
@@ -39,8 +62,15 @@ setup!
 
 class SoftDeleteTest < test_framework
   def setup
-    ActiveRecord::Base.connection.data_sources.each do |table|
-      ActiveRecord::Base.connection.execute "DELETE FROM #{table}"
+    connection = ActiveRecord::Base.connection
+    cleaner = ->(source) {
+      ActiveRecord::Base.connection.execute "DELETE FROM #{source}"
+    }
+
+    if ActiveRecord::VERSION::MAJOR < 5
+      connection.tables.each(&cleaner)
+    else
+      connection.data_sources.each(&cleaner)
     end
   end
 
@@ -71,7 +101,6 @@ class SoftDeleteTest < test_framework
     assert_equal to_param, model.to_param
   end
 
-  # Anti-regression test for #81, which would've introduced a bug to break this test.
   def test_soft_delete_behavior_for_plain_models_callbacks
     model = CallbackModel.new
     model.save
@@ -83,7 +112,23 @@ class SoftDeleteTest < test_framework
     assert_nil model.instance_variable_get(:@validate_called)
     assert_nil model.instance_variable_get(:@destroy_callback_called)
     assert_nil model.instance_variable_get(:@after_destroy_callback_called)
+    assert model.instance_variable_get(:@after_commit_callback_called)
+    assert model.instance_variable_get(:@after_soft_delete_callback_called)
+  end
 
+  def test_delete_in_transaction_behavior_for_plain_models_callbacks
+    model = CallbackModel.new
+    model.save
+    model.remove_called_variables     # clear called callback flags
+    CallbackModel.transaction do
+      model.soft_delete
+    end
+
+    assert_nil model.instance_variable_get(:@update_callback_called)
+    assert_nil model.instance_variable_get(:@save_callback_called)
+    assert_nil model.instance_variable_get(:@validate_called)
+    assert_nil model.instance_variable_get(:@destroy_callback_called)
+    assert_nil model.instance_variable_get(:@after_destroy_callback_called)
     assert model.instance_variable_get(:@after_commit_callback_called)
     assert model.instance_variable_get(:@after_soft_delete_callback_called)
   end
@@ -115,12 +160,115 @@ class SoftDeleteTest < test_framework
     p2 = SoftDeletableModel.create(:parent_model => parent2)
     p1.soft_delete
     p2.soft_delete
+
     assert_equal 0, parent1.soft_deletable_models.count
     assert_equal 1, parent1.soft_deletable_models.only_deleted.count
+
+    assert_equal 2, SoftDeletableModel.only_deleted.joins(:parent_model).count
     assert_equal 1, parent1.soft_deletable_models.deleted.count
+    assert_equal 0, parent1.soft_deletable_models.without_deleted.count
     p3 = SoftDeletableModel.create(:parent_model => parent1)
     assert_equal 2, parent1.soft_deletable_models.with_deleted.count
-    assert_equal [p1,p3], parent1.soft_deletable_models.with_deleted
+    assert_equal 1, parent1.soft_deletable_models.without_deleted.count
+    assert_equal [p1, p3], parent1.soft_deletable_models.with_deleted
+  end
+
+  def test_only_deleted_with_joins
+    c1 = ActiveColumnModelWithHasManyRelationship.create(name: 'Jacky')
+    c2 = ActiveColumnModelWithHasManyRelationship.create(name: 'Thomas')
+    p1 = SoftDeletableModelWithBelongsToActiveColumnModelWithHasManyRelationship.create(name: 'Hello', active_column_model_with_has_many_relationship: c1)
+
+    c1.soft_delete
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.count
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.count
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.joins(:soft_deletable_model_with_belongs_to_active_column_model_with_has_many_relationships).count
+  end
+
+  def test_soft_delete_behavior_for_custom_column_models
+    model = CustomColumnModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_nil model.destroyed_at
+    assert_equal 1, model.class.count
+    model.soft_delete
+
+    assert_equal false, model.destroyed_at.nil?
+    assert model.soft_deleted?
+
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 1, model.class.deleted.count
+  end
+
+  def test_default_sentinel_value
+    assert_nil SoftDeletableModel.soft_delete_sentinel_value
+  end
+
+  def test_without_default_scope_option
+    model = WithoutDefaultScopeModel.create
+    model.soft_delete
+    assert_equal 1, model.class.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 0, model.class.where(deleted_at: nil).count
+  end
+
+  def test_active_column_model
+    model = ActiveColumnModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_nil model.deleted_at
+    assert_equal true, model.active
+    assert_equal 1, model.class.count
+    model.soft_delete
+
+    assert_equal false, model.deleted_at.nil?
+    assert_nil model.active
+    assert model.soft_deleted?
+
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 1, model.class.deleted.count
+  end
+
+  def test_active_column_model_with_uniqueness_validation_only_checks_non_deleted_records
+    a = ActiveColumnModelWithUniquenessValidation.create!(name: "A")
+    a.soft_delete
+    b = ActiveColumnModelWithUniquenessValidation.new(name: "A")
+    assert b.valid?
+  end
+
+  def test_active_column_model_with_uniqueness_validation_still_works_on_non_deleted_records
+    a = ActiveColumnModelWithUniquenessValidation.create!(name: "A")
+    b = ActiveColumnModelWithUniquenessValidation.new(name: "A")
+    refute b.valid?
+  end
+
+  def test_sentinel_value_for_custom_sentinel_models
+    model = CustomSentinelModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_equal DateTime.new(0), model.deleted_at
+    assert_equal 1, model.class.count
+    model.soft_delete
+
+    assert DateTime.new(0) != model.deleted_at
+    assert model.soft_deleted?
+
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 1, model.class.deleted.count
+
+    model.restore
+    assert_equal DateTime.new(0), model.deleted_at
+    assert !model.soft_deleted?
+
+    assert_equal 1, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 0, model.class.only_deleted.count
+    assert_equal 0, model.class.deleted.count
   end
 
   def test_soft_delete_behavior_for_featureful_soft_deletable_models
@@ -141,7 +289,7 @@ class SoftDeleteTest < test_framework
     assert_equal({'name' => "foo"}, scope.where_values_hash)
   end
 
-  def test_only_destroyed_scope_for_soft_deletable_models
+  def test_only_deleted_scope_for_soft_deletable_models
     model = SoftDeletableModel.new
     model.save
     model.soft_delete
@@ -314,6 +462,31 @@ class SoftDeleteTest < test_framework
     refute c.soft_deleted?
   end
 
+  def test_soft_delete_not_propagated_on_associations
+    parent = ParentModel.create
+    child = parent.very_related_models.create
+
+    parent.soft_delete
+
+    assert_equal false, parent.deleted_at.nil?
+    assert_nil child.reload.deleted_at
+  end
+
+  def test_restore_not_propagated_on_associations
+    parent = ParentModel.create
+    child = parent.very_related_models.create
+
+    parent.soft_delete
+    child.soft_delete
+
+    assert_equal false, parent.deleted_at.nil?
+    assert child.soft_deleted?
+
+    parent.restore!
+    assert_nil parent.deleted_at
+    assert_equal false, child.reload.deleted_at.nil?
+  end
+
   def test_observers_notified
     a = SoftDeletableModelWithObservers.create
     a.soft_delete
@@ -343,6 +516,26 @@ class SoftDeleteTest < test_framework
     refute b.valid?
   end
 
+  def test_updated_at_modification_on_soft_delete
+    soft_deletable_model = SoftDeletableModelWithTimestamp.create(:parent_model => ParentModel.create, :updated_at => 1.day.ago)
+    assert soft_deletable_model.updated_at < 10.minutes.ago
+    soft_deletable_model.soft_delete
+    assert soft_deletable_model.updated_at > 10.minutes.ago
+  end
+
+  def test_updated_at_modification_on_restore
+    parent1 = ParentModel.create
+    pt1 = SoftDeletableModelWithTimestamp.create(:parent_model => parent1)
+    SoftDeletableModelWithTimestamp.record_timestamps = false
+    pt1.update_columns(created_at: 20.years.ago, updated_at: 10.years.ago, deleted_at: 10.years.ago)
+    SoftDeletableModelWithTimestamp.record_timestamps = true
+    assert pt1.updated_at < 10.minutes.ago
+    refute pt1.deleted_at.nil?
+    pt1.restore!
+    assert pt1.deleted_at.nil?
+    assert pt1.updated_at > 10.minutes.ago
+  end
+
   def test_soft_delete_fails_if_callback_raises_exception
     parent = AsplodeModel.create
 
@@ -369,6 +562,22 @@ class SoftDeleteTest < test_framework
   ensure
     setup!
   end
+
+  # Ensure that we're checking parent_type when restoring
+  def test_missing_restore_recursive_on_polymorphic_has_one_association
+    parent = ParentModel.create
+    polymorphic = PolymorphicModel.create(parent_id: parent.id, parent_type: 'SoftDeletableModel')
+
+    parent.soft_delete
+    polymorphic.soft_delete
+
+    assert_equal 0, polymorphic.class.count
+
+    parent.restore(recursive: true)
+
+    assert_equal 0, polymorphic.class.count
+  end
+
 
   def test_counter_cache_column_update_on_destroy
     parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
@@ -397,6 +606,47 @@ class SoftDeleteTest < test_framework
     related.valid?
   end
 
+  def test_assocation_not_soft_deleted_validator
+    not_soft_deleteable_model =
+    NotSoftDeletableModelWithBelongsAndAssocationNotSoftDeletedValidator.create
+    parent_model = ParentModel.create
+    assert not_soft_deleteable_model.valid?
+
+    not_soft_deleteable_model.parent_model = parent_model
+    assert not_soft_deleteable_model.valid?
+    parent_model.soft_delete
+    assert !not_soft_deleteable_model.valid?
+    assert not_soft_deleteable_model.errors.full_messages.include? "Parent model has been soft-deleted"
+  end
+
+  def test_counter_cache_column_on_double_soft_delete
+    parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+    related_model = parent_model_with_counter_cache_column.related_models.create
+
+    related_model.soft_delete
+    related_model.soft_delete
+    assert_equal 0, parent_model_with_counter_cache_column.reload.related_models_count
+  end
+
+  def test_counter_cache_column_on_double_restore
+    parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+    related_model = parent_model_with_counter_cache_column.related_models.create
+
+    related_model.soft_delete
+    related_model.restore
+    related_model.restore
+    assert_equal 1, parent_model_with_counter_cache_column.reload.related_models_count
+  end
+
+  def test_counter_cache_column_on_restore
+    parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+    related_model = parent_model_with_counter_cache_column.related_models.create
+
+    related_model.soft_delete
+    assert_equal 0, parent_model_with_counter_cache_column.reload.related_models_count
+    related_model.restore
+    assert_equal 1, parent_model_with_counter_cache_column.reload.related_models_count
+  end
 end
 
 # Helper classes
@@ -420,13 +670,24 @@ class FailCallbackModel < ActiveRecord::Base
   belongs_to :parent_model
   acts_as_soft_deletable
 
-  before_soft_delete { |_| throw :abort }
+  before_soft_delete { |_|
+    if ActiveRecord::VERSION::MAJOR < 5
+      false
+    else
+      throw :abort
+    end
+  }
 end
 
 class FeaturefulModel < ActiveRecord::Base
   acts_as_soft_deletable
   validates :name, :presence => true, :uniqueness => true
 end
+
+class NonSoftDeletableChildModel < ActiveRecord::Base
+  validates :name, :presence => true, :uniqueness => true
+end
+
 
 class PlainModel < ActiveRecord::Base
 end
@@ -495,6 +756,94 @@ class Job < ActiveRecord::Base
   belongs_to :employee
 end
 
+class CustomColumnModel < ActiveRecord::Base
+  acts_as_soft_deletable column: :destroyed_at
+end
+
+class CustomSentinelModel < ActiveRecord::Base
+  acts_as_soft_deletable sentinel_value: DateTime.new(0)
+end
+
+class WithoutDefaultScopeModel < ActiveRecord::Base
+  acts_as_soft_deletable without_default_scope: true
+end
+
+class ActiveColumnModel < ActiveRecord::Base
+  acts_as_soft_deletable column: :active, sentinel_value: true
+
+  def soft_delete_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def soft_delete_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
+class ActiveColumnModelWithUniquenessValidation < ActiveRecord::Base
+  validates :name, :uniqueness => true
+  acts_as_soft_deletable column: :active, sentinel_value: true
+
+  def soft_delete_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def soft_delete_destroy_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
+class ActiveColumnModelWithHasManyRelationship < ActiveRecord::Base
+  has_many :soft_deletable_model_with_belongs_to_active_column_model_with_has_many_relationships
+  acts_as_soft_deletable column: :active, sentinel_value: true
+
+  def soft_delete_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def soft_delete_destroy_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
+class SoftDeletableModelWithBelongsToActiveColumnModelWithHasManyRelationship < ActiveRecord::Base
+  belongs_to :active_column_model_with_has_many_relationship
+
+  acts_as_soft_deletable column: :active, sentinel_value: true
+
+  def soft_delete_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def soft_delete_destroy_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
 class NonSoftDeletableModel < ActiveRecord::Base
 end
 
@@ -508,6 +857,72 @@ class SoftDeletableModelWithObservers < SoftDeletableModel
   end
 end
 
+class SoftDeletableModelWithoutObservers < SoftDeletableModel
+  self.class.send(remove_method :notify_observers) if method_defined?(:notify_observers)
+end
+
+# refer back to regression test for #118
+class SoftDeletableModelWithHasOne < SoftDeletableModel
+  has_one :soft_deletable_model_with_belong, :dependent => :destroy
+  has_one :class_name_belong, :dependent => :destroy, :class_name => "SoftDeletableModelWithAnthorClassNameBelong"
+  has_one :soft_deletable_model_with_foreign_key_belong, :dependent => :destroy, :foreign_key => "has_one_foreign_key_id"
+  has_one :not_soft_deletable_model_with_belong, :dependent => :destroy
+end
+
+class SoftDeletableModelWithHasOneAndBuild < ActiveRecord::Base
+  has_one :soft_deletable_model_with_build_belong, :dependent => :destroy
+  validates :color, :presence => true
+  after_validation :build_soft_deletable_model_with_build_belong, on: :create
+
+  private
+  def build_soft_deletable_model_with_build_belong
+    super.tap { |child| child.name = "foo" }
+  end
+end
+
+class SoftDeletableModelWithBuildBelong < ActiveRecord::Base
+  acts_as_soft_deletable
+  validates :name, :presence => true
+  belongs_to :soft_deletable_model_with_has_one_and_build
+end
+
+class SoftDeletableModelWithBelong < ActiveRecord::Base
+  acts_as_soft_deletable
+  belongs_to :soft_deletable_model_with_has_one
+end
+
+class SoftDeletableModelWithAnthorClassNameBelong < ActiveRecord::Base
+  acts_as_soft_deletable
+  belongs_to :soft_deletable_model_with_has_one
+end
+
+class SoftDeletableModelWithForeignKeyBelong < ActiveRecord::Base
+  acts_as_soft_deletable
+  belongs_to :soft_deletable_model_with_has_one
+end
+
+class SoftDeletableModelWithTimestamp < ActiveRecord::Base
+  belongs_to :parent_model
+  acts_as_soft_deletable
+end
+
+class NotSoftDeletableModelWithBelong < ActiveRecord::Base
+  belongs_to :soft_deletable_model_with_has_one
+end
+
+class NotSoftDeletableModelWithBelongsAndAssocationNotSoftDeletedValidator < NotSoftDeletableModelWithBelong
+    belongs_to :parent_model
+    validates :parent_model, association_not_soft_deleted: true
+end
+
+class FlaggedModel < PlainModel
+  acts_as_soft_deletable :flag_column => :is_deleted
+end
+
+class FlaggedModelWithCustomIndex < PlainModel
+  acts_as_soft_deletable :flag_column => :is_deleted, :indexed_column => :is_deleted
+end
+
 class AsplodeModel < ActiveRecord::Base
   acts_as_soft_deletable
   before_soft_delete do |r|
@@ -516,4 +931,25 @@ class AsplodeModel < ActiveRecord::Base
 end
 
 class NoConnectionModel < ActiveRecord::Base
+end
+
+class PolymorphicModel < ActiveRecord::Base
+  acts_as_soft_deletable
+  belongs_to :parent, polymorphic: true
+end
+
+module Namespaced
+  def self.table_name_prefix
+    "namespaced_"
+  end
+
+  class SoftDeletableHasOne < ActiveRecord::Base
+    acts_as_soft_deletable
+    has_one :soft_deletable_belongs_to, dependent: :destroy
+  end
+
+  class SoftDeletableBelongsTo < ActiveRecord::Base
+    acts_as_soft_deletable
+    belongs_to :soft_deletable_has_one
+  end
 end

--- a/test/soft_delete_test.rb
+++ b/test/soft_delete_test.rb
@@ -31,6 +31,7 @@ def setup!
     'jobs' => 'employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME',
     'custom_column_models' => 'destroyed_at DATETIME',
     'custom_sentinel_models' => 'deleted_at DATETIME NOT NULL',
+    'non_soft_deletable_models' => 'parent_model_id INTEGER',
     'polymorphic_models' => 'parent_id INTEGER, parent_type STRING, deleted_at DATETIME',
     'non_soft_deletable_unique_models' => 'name VARCHAR(32), soft_deletable_with_non_soft_deletables_id INTEGER',
     'active_column_models' => 'deleted_at DATETIME, active BOOLEAN',
@@ -103,7 +104,9 @@ class SoftDeleteTest < test_framework
     assert_nil model.instance_variable_get(:@validate_called)
     assert_nil model.instance_variable_get(:@destroy_callback_called)
     assert_nil model.instance_variable_get(:@after_destroy_callback_called)
+
     assert model.instance_variable_get(:@after_commit_callback_called)
+    assert model.instance_variable_get(:@soft_delete_callback_called)
     assert model.instance_variable_get(:@after_soft_delete_callback_called)
   end
 
@@ -120,7 +123,9 @@ class SoftDeleteTest < test_framework
     assert_nil model.instance_variable_get(:@validate_called)
     assert_nil model.instance_variable_get(:@destroy_callback_called)
     assert_nil model.instance_variable_get(:@after_destroy_callback_called)
+
     assert model.instance_variable_get(:@after_commit_callback_called)
+    assert model.instance_variable_get(:@soft_delete_callback_called)
     assert model.instance_variable_get(:@after_soft_delete_callback_called)
   end
 
@@ -684,8 +689,9 @@ class CallbackModel < ActiveRecord::Base
   before_restore      { |model| model.instance_variable_set :@restore_callback_called, true }
   before_update       { |model| model.instance_variable_set :@update_callback_called, true }
   before_save         { |model| model.instance_variable_set :@save_callback_called, true}
-  before_soft_delete  { |model| model.instance_variable_set :@after_soft_delete_callback_called, true }
+  before_soft_delete  { |model| model.instance_variable_set :@soft_delete_callback_called, true }
 
+  after_soft_delete   { |model| model.instance_variable_set :@after_soft_delete_callback_called, true }
   after_destroy       { |model| model.instance_variable_set :@after_destroy_callback_called, true }
   after_commit        { |model| model.instance_variable_set :@after_commit_callback_called, true }
 


### PR DESCRIPTION
This PR intends to integrate the latest changes from [Paranoia](https://github.com/rubysherpas/paranoia) to SoftDelete preserving SoftDelete properties of not overwriting `destroy` nor `delete` methods from ActiveRecord and also preventing the deletion propagation through active record associations.

Main changes introduced from Paranoia:

* sentinel_value in order to be able to define unique indexes for non deleted records
* Ability to update custom attributes on soft deletion

For more added small options see [Paranoia documentation](https://github.com/rubysherpas/paranoia) 

This PR intends also to be tagged as v4.0.0 and from now on use master as main branch.
